### PR TITLE
Fix: 초대받은 본인만 수락/거절 가능하도록 api 변경

### DIFF
--- a/backend/src/features/teams/teams.controller.ts
+++ b/backend/src/features/teams/teams.controller.ts
@@ -40,7 +40,7 @@ const acceptInvite = async (req: Request, res: Response) => {
   }
 
   try {
-    const result = await teamsService.acceptInvite(inviteId);
+    const result = await teamsService.acceptInvite(inviteId, user.userId);
     res.status(StatusCodes.OK).json(result);
   } catch (error: any) {
     res.status(StatusCodes.BAD_REQUEST).json({
@@ -61,14 +61,14 @@ const rejectInvite = async (req: Request, res: Response) => {
   }
 
   try {
-    const result = await teamsService.rejectInvite(inviteId);
+    const result = await teamsService.rejectInvite(inviteId, user.userId);
     res.status(StatusCodes.OK).json(result);
   } catch (error: any) {
     res.status(StatusCodes.BAD_REQUEST).json({
       message: error.message
     });
   }
-}
+};
 
 const leaveTeam = async (req: Request, res: Response) => {
   const { teamId } = req.params;

--- a/backend/src/features/teams/teams.service.ts
+++ b/backend/src/features/teams/teams.service.ts
@@ -106,14 +106,20 @@ const inviteTeam = async (
   return invitation;
 };
 
-const acceptInvite = async (inviteId: string) => {
+const acceptInvite = async (inviteId: string, userId: string) => {
   const invitation = await prisma.team_invitations.findUnique({
     where: { id: inviteId },
- 
+    include: {
+      users_team_invitations_fk_user_idTousers: true
+    }
   });
 
   if (!invitation || invitation.status !== 'pending') {
     throw new Error('유효하지 않은 초대입니다.');
+  }
+
+  if (invitation.users_team_invitations_fk_user_idTousers.userId !== userId) {
+    throw new Error('초대받은 사용자가 아닙니다.');
   }
 
   return await prisma.$transaction([
@@ -134,16 +140,21 @@ const acceptInvite = async (inviteId: string) => {
   ]);
 };
 
-const rejectInvite = async (inviteId: string) => {
+const rejectInvite = async (inviteId: string, userId: string) => {
   const invitation = await prisma.team_invitations.findUnique({
     where: { id: inviteId },
-
+    include: {
+      users_team_invitations_fk_user_idTousers: true
+    }
   });
 
   if (!invitation || invitation.status !== 'pending') {
     throw new Error('유효하지 않은 초대입니다.');
   }
 
+  if (invitation.users_team_invitations_fk_user_idTousers.userId !== userId) {
+    throw new Error('초대받은 사용자가 아닙니다.');
+  }
 
   return await prisma.team_invitations.update({
     where: { id: inviteId },


### PR DESCRIPTION
팀원 추방 시 `UserId` -> `memberId`로 리팩토링 하는 과정에서 누락한 코드 복원